### PR TITLE
Update Dockerfile and README for source labeling and path changes

### DIFF
--- a/.github/workflows/build_and_push_image.yaml
+++ b/.github/workflows/build_and_push_image.yaml
@@ -1,8 +1,9 @@
 name: Build and Push Image
 
 on:
-  push: 
-    branches: [ latest ]
+  push:
+    tags:
+      - 'v*.*.*'
 
 env:
   REGISTRY: ghcr.io
@@ -35,6 +36,14 @@ jobs:
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{raw}}
+            type=raw,value=latest
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision={{sha}}
+            org.opencontainers.image.version={{tag}}
+            org.opencontainers.image.created={{commit_date 'YYYY-MM-DDTHH:mm:ss.SSS[Z]'}}
 
       - name: Build and push Docker image
         id: push

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # Use an official Python runtime as a parent image
 FROM python:3.14.4-slim-trixie
 
+LABEL org.opencontainers.image.source="https://github.com/SASlabgroup/microSWIFT-Dashboard"
+
 # Set the working directory in the container
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -65,15 +65,23 @@ podman compose up
 ## Running a pre-built container
 To run a pre-built container in Docker:
 ```shell
-docker pull ghcr.io/apl-uw-software/microswift-dashboard:latest
-docker run -p 8080:8080 ghcr.io/apl-uw-software/microswift-dashboard:latest
+docker pull ghcr.io/saslabgroup/microswift-dashboard:latest
+docker run -p 8080:8080 ghcr.io/saslabgroup/microswift-dashboard:latest
 ```
 
 To run a pre-build container in Podman:
 ```shell
-podman pull ghcr.io/apl-uw-software/microswift-dashboard:latest
-podman run -p 8080:8080 ghcr.io/apl-uw-software/microswift-dashboard:latest
+podman pull ghcr.io/saslabgroup/microswift-dashboard:latest
+podman run -p 8080:8080 ghcr.io/saslabgroup/microswift-dashboard:latest
 ```
+
+For automated dependency updates in downstream repositories, pin immutable release tags instead of latest:
+
+```shell
+ghcr.io/saslabgroup/microswift-dashboard:v1.2.3
+```
+
+Release tags are published from stable Git tags in this repository using the format vX.Y.Z.
 
 # Deployment
 While Dash recommends using Heroku for deployment, we suggest using Render for its simplicity. For deployment on Render, follow their <a href="https://github.com/thusharabandara/dash-app-render-deployment">deployment guide</a>. <b>Note:</b> You will need to create a Render account.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ docker pull ghcr.io/saslabgroup/microswift-dashboard:latest
 docker run -p 8080:8080 ghcr.io/saslabgroup/microswift-dashboard:latest
 ```
 
-To run a pre-build container in Podman:
+To run a pre-built container in Podman:
 ```shell
 podman pull ghcr.io/saslabgroup/microswift-dashboard:latest
 podman run -p 8080:8080 ghcr.io/saslabgroup/microswift-dashboard:latest


### PR DESCRIPTION
This pull request updates the Docker image build and release workflow to use semantic version tags, improves container metadata, and updates documentation to reflect the new image location and tagging strategy. The main changes are grouped below.

**CI/CD Workflow Improvements:**

* The GitHub Actions workflow in `.github/workflows/build_and_push_image.yaml` now triggers on semantic version tags (e.g., `v1.2.3`) instead of on pushes to the `latest` branch.
* The Docker image metadata now includes both semver and `latest` tags, and adds Open Containers Initiative (OCI) labels for source, revision, version, and creation time.

**Container Metadata:**

* The `Dockerfile` now includes an OCI label for the image source repository.

**Documentation Updates:**

* The `README.md` has been updated to use the new image location (`ghcr.io/saslabgroup/microswift-dashboard`) and to recommend using immutable release tags (e.g., `v1.2.3`) for downstream dependency updates.…changes