### PR TITLE
Fix semver pattern in Docker metadata extraction

### DIFF
--- a/.github/workflows/build_and_push_image.yaml
+++ b/.github/workflows/build_and_push_image.yaml
@@ -37,7 +37,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=semver,pattern={{raw}}
+            type=semver,pattern={{version}}
             type=raw,value=latest
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}


### PR DESCRIPTION
This pull request makes a small update to the Docker image build workflow. The change updates the tag pattern for semantic versioning from `{{raw}}` to `{{version}}` in the `.github/workflows/build_and_push_image.yaml` file.