### PR TITLE
Bump Pillow version to 12.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ nest-asyncio==1.6.0
 numpy==2.5.1
 packaging==26.2
 pandas==3.0.3
-pillow==12.2.0
+pillow==12.3.0
 plotly==6.8.0
 pyparsing==3.3.2
 python-dateutil==2.9.0.post0


### PR DESCRIPTION
Update the Pillow dependency to version 12.3.0 for security fixes.