### PR TITLE
Remove unused GitPython and gitdb from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,6 @@ dash==4.4.1
 dash-bootstrap-components==2.0.4
 Flask==3.1.3
 fonttools==4.63.0
-gitdb==4.0.12
-GitPython==3.1.59
 gunicorn==26.0.0
 idna==3.18
 importlib_metadata==9.0.0


### PR DESCRIPTION
Eliminate GitPython and gitdb from the requirements file as they are not utilized in the project.